### PR TITLE
Rewrite updateEnabledState()

### DIFF
--- a/src/org/openstreetmap/josm/plugins/pt_assistant/actions/MendRelationAction.java
+++ b/src/org/openstreetmap/josm/plugins/pt_assistant/actions/MendRelationAction.java
@@ -207,17 +207,15 @@ public class MendRelationAction extends AbstractRelationEditorAction {
 
     @Override
     protected void updateEnabledState() {
-        if (relation != null && !((relation.hasTag("route", "bus") && relation.hasTag("public_transport:version", "2"))
-                || (RouteUtils.isPTRoute(relation) && !relation.hasTag("route", "bus")))) {
-            setEnabled(false);
-            return;
-        }
-        if (!setEnable) {
-            setEnabled(false);
-            return;
-        }
-        // only enable the action if we have members referring to the selected primitives
-        setEnabled(true);
+        final Relation curRel = relation;
+
+        setEnabled(
+            curRel != null && setEnable &&
+            (
+                (curRel.hasTag("route", "bus") && curRel.hasTag("public_transport:version", "2")) ||
+                (RouteUtils.isPTRoute(curRel) && !curRel.hasTag("route", "bus"))
+            )
+        );
     }
 
     @Override

--- a/src/org/openstreetmap/josm/plugins/pt_assistant/actions/SortPTRouteMembersAction.java
+++ b/src/org/openstreetmap/josm/plugins/pt_assistant/actions/SortPTRouteMembersAction.java
@@ -394,10 +394,6 @@ public class SortPTRouteMembersAction extends AbstractRelationEditorAction {
 
     @Override
     protected void updateEnabledState() {
-        if (editor != null && !RouteUtils.isPTRoute(editor.getRelation())) {
-            setEnabled(false);
-            return;
-        }
-        setEnabled(true);
+        setEnabled(editor != null && RouteUtils.isPTRoute(editor.getRelation()));
     }
 }


### PR DESCRIPTION
This PR rewrites the method `updateEnabledState()` of `MendRelationAction` and `SortPTRouteMembersAction` to be more concise.

While doing this, I noticed that these actions sometimes get enabled when:

* the relation is null: https://github.com/JOSM/pt_assistant/blob/86f9b8283a8b6e1b87ef945af48b9be54fb48ea4/src/org/openstreetmap/josm/plugins/pt_assistant/actions/MendRelationAction.java#L215
* or the editor is null: https://github.com/JOSM/pt_assistant/blob/86f9b8283a8b6e1b87ef945af48b9be54fb48ea4/src/org/openstreetmap/josm/plugins/pt_assistant/actions/SortPTRouteMembersAction.java#L397

This doesn't seem right and might cause trouble (NPEs), right? Or are there cases where the actions make sense even if those variables are null?