### PR TITLE
Create an AddNearestWayAction

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/PTAssistantPlugin.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/PTAssistantPlugin.java
@@ -8,6 +8,7 @@ import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import javax.swing.JMenu;
@@ -198,7 +199,7 @@ public class PTAssistantPlugin extends Plugin {
         IRelationEditorActionGroup group3 = new IRelationEditorActionGroup() {
             @Override
             public List<AbstractRelationEditorAction> getActions(IRelationEditorActionAccess editorAccess) {
-                return Arrays.asList(new AddNearestWayAction(editorAccess));
+                return Collections.singletonList(new AddNearestWayAction(editorAccess));
             }
         };
         RelationEditorHooks.addActionsToMembers(group1);

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/PTAssistantPlugin.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/PTAssistantPlugin.java
@@ -27,6 +27,7 @@ import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
 import org.openstreetmap.josm.plugins.customizepublictransportstop.CustomizeStopAction;
+import org.openstreetmap.josm.plugins.pt_assistant.actions.AddNearestWayAction;
 import org.openstreetmap.josm.plugins.pt_assistant.actions.AddStopPositionAction;
 import org.openstreetmap.josm.plugins.pt_assistant.actions.CreatePlatformNodeAction;
 import org.openstreetmap.josm.plugins.pt_assistant.actions.CreatePlatformNodeThroughReplaceAction;
@@ -194,7 +195,15 @@ public class PTAssistantPlugin extends Plugin {
                 return Arrays.asList(new SortPTRouteMembersAction(editorAccess));
             }
         };
+        IRelationEditorActionGroup group3 = new IRelationEditorActionGroup() {
+            @Override
+            public List<AbstractRelationEditorAction> getActions(IRelationEditorActionAccess editorAccess) {
+                return Arrays.asList(new AddNearestWayAction(editorAccess));
+            }
+        };
         RelationEditorHooks.addActionsToMembers(group1);
         RelationEditorHooks.addActionsToMembers(group2);
+        RelationEditorHooks.addActionsToMembers(group3);
+
     }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/AddNearestWayAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/AddNearestWayAction.java
@@ -1,0 +1,61 @@
+package org.openstreetmap.josm.plugins.pt_assistant.actions;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.awt.event.ActionEvent;
+import java.util.Collection;
+
+import org.openstreetmap.josm.command.ChangeCommand;
+import org.openstreetmap.josm.data.UndoRedoHandler;
+import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.data.osm.OsmPrimitiveType;
+import org.openstreetmap.josm.data.osm.Relation;
+import org.openstreetmap.josm.data.osm.RelationMember;
+import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.gui.dialogs.relation.GenericRelationEditor;
+import org.openstreetmap.josm.gui.dialogs.relation.actions.AbstractRelationEditorAction;
+import org.openstreetmap.josm.gui.dialogs.relation.actions.IRelationEditorActionAccess;
+import org.openstreetmap.josm.gui.dialogs.relation.actions.IRelationEditorUpdateOn;
+import org.openstreetmap.josm.tools.ImageProvider;
+
+public class AddNearestWayAction extends AbstractRelationEditorAction {
+
+    private Relation relation = null;
+    private GenericRelationEditor editor = null;
+    boolean setEnable = true;
+
+    public AddNearestWayAction(IRelationEditorActionAccess editorAccess){
+        super(editorAccess, IRelationEditorUpdateOn.MEMBER_TABLE_SELECTION);
+        putValue(SHORT_DESCRIPTION, tr("Add Nearest Way"));
+        new ImageProvider("dialogs/relation", "routing_assistance.svg").getResource().attachImageIcon(this, true);
+        updateEnabledState();
+        editor = (GenericRelationEditor) editorAccess.getEditor();
+        this.relation = editor.getRelation();
+        editor.addWindowListener(new RoutingAction.WindowEventHandler());
+    }
+
+    @Override
+    protected void updateEnabledState() {
+        setEnabled(true);
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent actionEvent) {
+        Relation newRel = new Relation(editor.getRelation());
+        editor.apply();
+
+        for (RelationMember rm : newRel.getMembers()) {
+            if (rm.getType() == OsmPrimitiveType.WAY && rm.getRole().equals("stop")) {
+                DataSet data = rm.getNode().getDataSet();
+                Collection<Way> ways = data.getWays();
+
+                // add each way that is adjacent and not already in the relation
+                ways.stream()
+                    .filter(w -> w.containsNode(rm.getNode()) && !newRel.getMembers().contains(w))
+                    .forEach(w -> newRel.addMember(new RelationMember("way", w)));
+            }
+        }
+        UndoRedoHandler.getInstance().add(new ChangeCommand(editor.getRelation(), newRel));
+        editor.reloadDataFromRelation();
+    }
+}

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/AddNearestWayAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/AddNearestWayAction.java
@@ -3,59 +3,66 @@ package org.openstreetmap.josm.plugins.pt_assistant.actions;
 import static org.openstreetmap.josm.tools.I18n.tr;
 
 import java.awt.event.ActionEvent;
-import java.util.Collection;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import org.openstreetmap.josm.command.ChangeCommand;
-import org.openstreetmap.josm.data.UndoRedoHandler;
-import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.osm.OsmPrimitiveType;
-import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.RelationMember;
 import org.openstreetmap.josm.data.osm.Way;
-import org.openstreetmap.josm.gui.dialogs.relation.GenericRelationEditor;
+import org.openstreetmap.josm.gui.Notification;
 import org.openstreetmap.josm.gui.dialogs.relation.actions.AbstractRelationEditorAction;
 import org.openstreetmap.josm.gui.dialogs.relation.actions.IRelationEditorActionAccess;
 import org.openstreetmap.josm.gui.dialogs.relation.actions.IRelationEditorUpdateOn;
+import org.openstreetmap.josm.tools.I18n;
 import org.openstreetmap.josm.tools.ImageProvider;
 
+
+/**
+ * For all nodes with role "stop" in the relation, finds all ways that contain at least one of those nodes.
+ * All found ways are then added to the end of the member list.
+ */
 public class AddNearestWayAction extends AbstractRelationEditorAction {
 
-    private Relation relation = null;
-    private GenericRelationEditor editor = null;
-    boolean setEnable = true;
+    private static final List<String> POSSIBLE_ROUTE_TYPES = Arrays.asList("bus", "railway");
 
     public AddNearestWayAction(IRelationEditorActionAccess editorAccess){
-        super(editorAccess, IRelationEditorUpdateOn.MEMBER_TABLE_SELECTION);
-        putValue(SHORT_DESCRIPTION, tr("Add Nearest Way"));
+        super(
+            editorAccess,
+            IRelationEditorUpdateOn.MEMBER_TABLE_CHANGE,
+            IRelationEditorUpdateOn.MEMBER_TABLE_SELECTION,
+            IRelationEditorUpdateOn.TAG_CHANGE
+        );
+        putValue(SHORT_DESCRIPTION, tr("Add ways connected to stop positions"));
         new ImageProvider("dialogs/relation", "routing_assistance.svg").getResource().attachImageIcon(this, true);
         updateEnabledState();
-        editor = (GenericRelationEditor) editorAccess.getEditor();
-        this.relation = editor.getRelation();
-        editor.addWindowListener(new RoutingAction.WindowEventHandler());
     }
 
     @Override
     protected void updateEnabledState() {
-        setEnabled(true);
+        final String routeType = editorAccess.getTagModel().get("route").getValue();
+
+        setEnabled(routeType != null && POSSIBLE_ROUTE_TYPES.contains(routeType));
     }
 
     @Override
     public void actionPerformed(ActionEvent actionEvent) {
-        Relation newRel = new Relation(editor.getRelation());
-        editor.apply();
+        final Set<RelationMember> prevMembers = IntStream.range(0, editorAccess.getMemberTableModel().getRowCount())
+            .mapToObj(i -> editorAccess.getMemberTableModel().getValue(i))
+            .collect(Collectors.toSet());
 
-        for (RelationMember rm : newRel.getMembers()) {
-            if (rm.getType() == OsmPrimitiveType.WAY && rm.getRole().equals("stop")) {
-                DataSet data = rm.getNode().getDataSet();
-                Collection<Way> ways = data.getWays();
+        final List<Way> newMembers = prevMembers.stream()
+            .filter(member -> member.getType() == OsmPrimitiveType.NODE && "stop".equals(member.getRole()))
+            .flatMap(member ->
+                member.getNode().getDataSet().getWays().stream()
+                    .filter(w -> w.containsNode(member.getNode()) && prevMembers.stream().noneMatch(it -> w.equals(it.getMember())))
+            )
+            .distinct()
+            .collect(Collectors.toList());
 
-                // add each way that is adjacent and not already in the relation
-                ways.stream()
-                    .filter(w -> w.containsNode(rm.getNode()) && !newRel.getMembers().contains(w))
-                    .forEach(w -> newRel.addMember(new RelationMember("way", w)));
-            }
-        }
-        UndoRedoHandler.getInstance().add(new ChangeCommand(editor.getRelation(), newRel));
-        editor.reloadDataFromRelation();
+        editorAccess.getMemberTableModel().addMembersAtEnd(newMembers);
+        new Notification(I18n.trn("Adding {0} new way to the relation", "Adding {0} new ways to the relation", newMembers.size())).show();
     }
 }

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/RoutingAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/RoutingAction.java
@@ -41,7 +41,6 @@ public class RoutingAction extends AbstractRelationEditorAction{
     updateEnabledState();
     editor = (GenericRelationEditor) editorAccess.getEditor();
     this.relation = editor.getRelation();
-    editor.addWindowListener(new WindowEventHandler());
   }
   @Override
   protected void updateEnabledState() {
@@ -93,7 +92,5 @@ public class RoutingAction extends AbstractRelationEditorAction{
               Logging.error(e1);
           }
       });
-  }
-  static class WindowEventHandler extends WindowAdapter {
   }
 }


### PR DESCRIPTION
@PolyglotOpenstreetmap @sudhanshu2 @michaelzangl I stumbled across this commit from march that added the new AddNearestWayAction: https://github.com/Fishysituation/pt_assistant/commit/a146a8d797adb97adbb3cfe1004d12678b1c2ba2 (I guess as part of a GSoC application)

If such an action would still be useful, we could merge this so it wasn't for nothing. In an effort to also re-familiarize myself with some intricacies of JOSM programming, I reworked it a bit, so the basic functionality is working.

It currently finds all nodes with role "stop" in the route relation and adds the ways connected to this node to the relation.

Issues that still exist:
* the icon is borrowed from the routing helper, would need a different one
* there's no checks on what the connected ways are (ideally only highways/railways should be added)
* the ways are added at the end of the relation, not where they would fit in best
* only ways of which the "stop" node is part of are added, ways that are just near the stop position are not accounted for