### PR TITLE
Add contribution guidelines and share IntelliJ run configurations for `runJosm` and `dist` tasks

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -18,5 +18,18 @@
         </value>
       </option>
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+    </JetCodeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/runConfigurations/Create_pt_assistant_distribution__dist_.xml
+++ b/.idea/runConfigurations/Create_pt_assistant_distribution__dist_.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Create pt_assistant distribution [dist]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="dist" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Run_JOSM_with_pt_assistant__runJosm_.xml
+++ b/.idea/runConfigurations/Run_JOSM_with_pt_assistant__runJosm_.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run JOSM with pt_assistant [runJosm]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runJosm" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-PT Assistant
-============
+# PT Assistant
 
 The JOSM plugin "Public Transport Assistant" (pt_assistant).
 Displays stops of selected public transport routes as graph.
+
+You are very welcome to contribute to this project! See our [contribution guidelines](./docs/CONTRIBUTING.md).
 
 Authors:
 * Darya Golovko <darya0705@gmail.com>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import java.net.URL
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
   java
@@ -69,7 +69,7 @@ tasks.withType(ProcessResources::class).getByName(sourceSets["main"].processReso
   from(projectDir) {
     include("images/**")
     include("GPL-*")
-    include("README")
+    include("README.md")
     include("LICENSE")
   }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to this project
+
+Contributions to this project are always welcome! You can either contribute translations of the texts used in the plugin, or contribute to the code.
+
+## Translation
+
+Translations are managed at Transifex: https://www.transifex.com/josm/josm/josm-plugin_pt_assistant/
+
+You can contribute translations for the texts used in this project at the link above. For this currently a Transifex account is required (login with GitHub, Google or LinkedIn is possible).
+
+🇬🇧 English is used as the baseline language by the developers, so changes to English texts need to be made in the code (see next section about code changes).
+
+[![translation status](https://www.transifex.com/projects/p/josm/resource/josm-plugin_pt_assistant/chart/image_png/)](https://www.transifex.com/josm/josm/josm-plugin_pt_assistant/)
+
+## Code
+
+> **Quick note beforehand:** Before you start working on a big new feature, you are welcome to [open a new issue](https://github.com/JOSM/pt_assistant/issues/new/choose) describing the planned changes.
+>
+> In case there is already a ticket open in [the JOSM trac](https://josm.openstreetmap.de/query?status=assigned&status=needinfo&status=new&status=reopened&component=Plugin+pt_assistant&col=id&col=summary&col=status&col=component&col=type&col=priority&col=milestone&col=time&col=changetime&report=1&desc=1&order=changetime) or on [GitHub](https://github.com/JOSM/pt_assistant/issues), just comment there that you intend to work on this.
+>
+> That way the other developers are aware you are already working on that and could also give feedback on your plans from the start.
+
+
+To get started with contributing code, make sure you have [Git](https://git-scm.com) and also a [Java Development Kit (JDK)](https://adoptopenjdk.net) of version 8 or later.
+
+---
+
+Clone the repository by going to the directory into which the project directory should go and use **one of** these lines in the command line:
+```shell script
+git clone https://github.com/JOSM/pt_assistant.git
+git clone https://gitlab.com/JOSM/plugin/pt_assistant.git
+```
+
+---
+
+Then you can enter the newly created project directory `pt_assistant` and should be able to build the project.
+
+We are using Gradle as build system, so you can run the following to see which tasks are available to run on the project:
+
+On Windows:
+```shell script
+gradlew.bat tasks
+```
+On other OSes:
+```shell script
+./gradlew tasks
+```
+
+---
+
+To then run a task of your choice, run the following on the command line (replace `‹task_name›` with the name of the task, of course 😉):
+
+On Windows:
+```shell script
+gradlew.bat ‹task_name›
+```
+On other OSes:
+```shell script
+./gradlew ‹task_name›
+```
+
+These are some tasks that will probably be useful for development:
+* `runJosm`: compiles the plugin and starts a clean JOSM instance (independent of any JOSM installations on your system) with just the current state of the plugin loaded
+* `build`: runs a complete build including running unit tests
+* `test`: runs just the unit tests with reports in `$projectDir/build/reports/`
+* `dist`: builds the distribution *.jar file in `$projectDir/build/dist/`
+* `compileJava_minJosm`, `compileJava_testedJosm`, `compileJava_latestJosm`: compiles the plugin against the JOSM version set as minimum compatible version, or the current `latest` or `tested` JOSM versions
+* …
+
+The `gradle-josm-plugin` also has some documentation on how to develop Gradle-based JOSM plugins: [https://gitlab.com/floscher/gradle-josm-plugin](https://gitlab.com/floscher/gradle-josm-plugin/-/blob/master/README.md)
+
+---
+
+Feel free to use the IDE of your choice, usually when the IDE supports it (e.g. IntelliJ idea or Eclipse do) you should be able to import as a Gradle project relatively easily. For IntelliJ idea and Eclipse there are also some files with settings already present that should make it easier to open the project in those IDEs.
+
+---
+
+If you want to submit your code contribution, fork [our GitHub repository](https://github.com/JOSM/pt_assistant), push your changes to the fork and [open a pull request](https://github.com/JOSM/pt_assistant/compare). We will then review the code and merge the pull request, if it looks good.


### PR DESCRIPTION
Fixes #27, this adds contribution guidelines for contributing code and translations.

See here for the `CONTRIBUTING.md` file: https://github.com/JOSM/pt_assistant/blob/contribution_guidelines/docs/CONTRIBUTING.md