### PR TITLE
Add support for highway=busway

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/customizepublictransportstop/OSMTags.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/customizepublictransportstop/OSMTags.java
@@ -17,6 +17,7 @@ public final class OSMTags {
     public static final String TRUNK_LINK_TAG_VALUE = "trunk_link";
     public static final String ROAD_TAG_VALUE = "road";
     public static final String BUS_GUIDEWAY_TAG_VALUE = "bus_guideway";
+    public static final String BUSWAY_TAG_VALUE = "busway";
     public static final String SERVICE_TAG_VALUE = "service";
     public static final String RESIDENTIAL_TAG_VALUE = "residential";
     public static final String UNCLASSIFIED_TAG_VALUE = "unclassified";
@@ -34,6 +35,7 @@ public final class OSMTags {
         RESIDENTIAL_TAG_VALUE,
         SERVICE_TAG_VALUE,
         BUS_GUIDEWAY_TAG_VALUE,
+        BUSWAY_TAG_VALUE,
         ROAD_TAG_VALUE,
         TRUNK_LINK_TAG_VALUE,
         PRIMARY_LINK_TAG_VALUE,

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/utils/RouteUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/utils/RouteUtils.java
@@ -232,7 +232,7 @@ public final class RouteUtils {
 
         String[] acceptedHighwayTags = new String[] {"motorway", "trunk", "primary", "secondary", "tertiary",
                 "unclassified", "road", "residential", "service", "motorway_link", "trunk_link", "primary_link",
-                "secondary_link", "tertiary_link", "living_street", "bus_guideway", "road" };
+                "secondary_link", "tertiary_link", "living_street", "busway", "bus_guideway", "road" };
 
         if (way.hasTag("highway", acceptedHighwayTags) || way.hasTag("cycleway", "share_busway")
                 || way.hasTag("cycleway", "shared_lane")) {

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/utils/WayUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/utils/WayUtils.java
@@ -118,7 +118,7 @@ public final class WayUtils {
                 "highway",
                 "motorway", "trunk", "primary", "secondary", "tertiary",
                 "unclassified", "road", "residential", "service", "motorway_link", "trunk_link", "primary_link",
-                "secondary_link", "tertiary_link", "living_street", "bus_guideway", "road"
+                "secondary_link", "tertiary_link", "living_street", "busway", "bus_guideway", "road"
             )
             || way.hasTag(
                 "cycleway",


### PR DESCRIPTION
highway=busway is approved and used about 5k times now. Additionally it's already rendered by the JOSM core. Support in this plug-in was missing so far though. This should fix the majority of the errors