### PR TITLE
Disable edit actions on non-editable layers

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/AddStopPositionAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/AddStopPositionAction.java
@@ -32,6 +32,7 @@ import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.RelationMember;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.WaySegment;
+import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.plugins.pt_assistant.PTAssistantPluginPreferences;
 import org.openstreetmap.josm.plugins.pt_assistant.data.PTStop;
@@ -74,7 +75,19 @@ public class AddStopPositionAction extends MapMode {
     }
 
     @Override
+    public boolean layerIsSupported(Layer l) {
+        return isEditableDataLayer(l);
+    }
+
+    @Override
+    protected void updateEnabledState() {
+        setEnabled(getLayerManager().getEditLayer() != null);
+    }
+
+    @Override
     public void enterMode() {
+        if (!isEnabled())
+            return;
         super.enterMode();
         MainApplication.getMap().mapView.addMouseListener(this);
         MainApplication.getMap().mapView.addMouseMotionListener(this);

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/DoubleSplitAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/DoubleSplitAction.java
@@ -54,6 +54,7 @@ import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.MapView;
 import org.openstreetmap.josm.gui.layer.AbstractMapViewPaintable;
+import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.plugins.pt_assistant.utils.NodeUtils;
 import org.openstreetmap.josm.plugins.pt_assistant.utils.PrimitiveUtils;
 import org.openstreetmap.josm.plugins.pt_assistant.utils.WayUtils;
@@ -103,7 +104,19 @@ public class DoubleSplitAction extends MapMode implements KeyListener {
     }
 
     @Override
+    public boolean layerIsSupported(Layer l) {
+        return isEditableDataLayer(l);
+    }
+
+    @Override
+    protected void updateEnabledState() {
+        setEnabled(getLayerManager().getEditLayer() != null);
+    }
+
+    @Override
     public void enterMode() {
+        if (!isEnabled())
+            return;
         super.enterMode();
         MainApplication.getMap().mapView.addMouseListener(this);
         MainApplication.getMap().mapView.addMouseMotionListener(this);


### PR DESCRIPTION
Prevent edit modes from being activated on non-editable layers. 

See also https://josm.openstreetmap.de/ticket/17465#comment:12

Activating these modes on non-editable layers causes some problems
```
java.lang.NullPointerException
        at org.openstreetmap.josm.plugins.pt_assistant.actions.AddStopPositionAction.updateHighlights(AddStopPositionAction.java:274)
        at org.openstreetmap.josm.plugins.pt_assistant.actions.AddStopPositionAction.mouseMoved(AddStopPositionAction.java:115)
        at java.desktop/java.awt.AWTEventMulticaster.mouseMoved(AWTEventMulticaster.java:338)
        at java.desktop/java.awt.Component.processMouseMotionEvent(Component.java:6677)
        at java.desktop/javax.swing.JComponent.processMouseMotionEvent(JComponent.java:3360)
        at java.desktop/java.awt.Component.processEvent(Component.java:6401)
        at java.desktop/java.awt.Container.processEvent(Container.java:2263)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5008)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
        at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
        at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4560)
        at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
        at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2762)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

```
java.lang.IllegalArgumentException: Parameter 'data' must not be null
        at org.openstreetmap.josm.tools.CheckParameterUtil.ensureParameterNotNull(CheckParameterUtil.java:26)
        at org.openstreetmap.josm.command.Command.<init>(Command.java:138)
        at org.openstreetmap.josm.command.AddCommand.<init>(AddCommand.java:41)
        at org.openstreetmap.josm.plugins.pt_assistant.actions.AddStopPositionAction.mouseClicked(AddStopPositionAction.java:133)
        at java.desktop/java.awt.AWTEventMulticaster.mouseClicked(AWTEventMulticaster.java:278)
        at java.desktop/java.awt.Component.processMouseEvent(Component.java:6635)
        at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3342)
        at java.desktop/java.awt.Component.processEvent(Component.java:6397)
        at java.desktop/java.awt.Container.processEvent(Container.java:2263)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5008)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
        at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
        at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4556)
        at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
        at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2762)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

```
java.lang.NullPointerException
        at org.openstreetmap.josm.plugins.pt_assistant.actions.DoubleSplitAction.updateHighlights(DoubleSplitAction.java:693)
        at org.openstreetmap.josm.plugins.pt_assistant.actions.DoubleSplitAction.reset(DoubleSplitAction.java:128)
        at org.openstreetmap.josm.plugins.pt_assistant.actions.DoubleSplitAction.exitMode(DoubleSplitAction.java:116)
        at org.openstreetmap.josm.gui.MapFrame.selectMapMode(MapFrame.java:498)
        at org.openstreetmap.josm.gui.MapFrame.selectMapMode(MapFrame.java:475)
        at org.openstreetmap.josm.actions.mapmode.MapMode.actionPerformed(MapMode.java:115)
        at java.desktop/javax.swing.SwingUtilities.notifyAction(SwingUtilities.java:1810)
        at java.desktop/javax.swing.JComponent.processKeyBinding(JComponent.java:2900)
        at java.desktop/javax.swing.KeyboardManager.fireBinding(KeyboardManager.java:311)
        at java.desktop/javax.swing.KeyboardManager.fireKeyboardAction(KeyboardManager.java:266)
        at java.desktop/javax.swing.JComponent.processKeyBindingsForAllComponents(JComponent.java:2993)
        at java.desktop/javax.swing.JComponent.processKeyBindings(JComponent.java:2985)
        at java.desktop/javax.swing.JComponent.processKeyEvent(JComponent.java:2862)
        at java.desktop/java.awt.Component.processEvent(Component.java:6409)
        at java.desktop/java.awt.Container.processEvent(Container.java:2263)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5008)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
        at java.desktop/java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1950)
        at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:870)
        at java.desktop/java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1139)
        at java.desktop/java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:1009)
        at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:835)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4889)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
        at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2762)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:389)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```