### PR TITLE
Fix #23708 Only check restrictions with subtypes

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
@@ -1122,19 +1122,14 @@ public class PublicTransportMendRelationAction extends AbstractMendRelation {
             else {
                 boolean remove = true;
                 String routeValue = relation.get("route");
-                String[] restrictionTypes = Arrays.stream(restrictions)
-                    .filter(s -> s.startsWith("restriction:"))
-                    .map(s -> s.substring("restriction:".length()))
-                    .toArray(String[]::new);
-
-                for (String type : restrictionTypes) {
-                    if (!routeValue.equals(type)) {
+                for (String s : restrictions) {
+                    if (s.length() <= 12)
                         continue;
-                    }
-
-                    if (rel.hasKey("restriction:" + type) || rel.hasTag("type", type)) {
+                    String sub = s.substring(12);
+                    if (routeValue.equals(sub) && rel.hasTag("type", s))
                         remove = false;
-                    }
+                    else if (routeValue.equals(sub) && rel.hasKey("restriction:" + sub))
+                        remove = false;
                 }
                 return remove;
             }

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
@@ -1120,14 +1120,9 @@ public class PublicTransportMendRelationAction extends AbstractMendRelation {
             else if (rel.hasTag("type", "restriction") && rel.hasKey("restriction"))
                 return false;
             else {
-                String routeValue = relation.get("route");
+                final String routeValue = Optional.ofNullable(relation.get("route")).map(it -> "restriction:" + it).orElse("");
                 for (String s : restrictions) {
-                    if (s.length() <= 12)
-                        continue;
-                    String sub = s.substring(12);
-                    if (routeValue.equals(sub) && rel.hasTag("type", s))
-                        return false;
-                    else if (routeValue.equals(sub) && rel.hasKey("restriction:" + sub))
+                    if (routeValue.equals(s) && (rel.hasTag("type", s) || rel.hasKey(s)))
                         return false;
                 }
                 return true;

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
@@ -1120,18 +1120,17 @@ public class PublicTransportMendRelationAction extends AbstractMendRelation {
             else if (rel.hasTag("type", "restriction") && rel.hasKey("restriction"))
                 return false;
             else {
-                boolean remove = true;
                 String routeValue = relation.get("route");
                 for (String s : restrictions) {
                     if (s.length() <= 12)
                         continue;
                     String sub = s.substring(12);
                     if (routeValue.equals(sub) && rel.hasTag("type", s))
-                        remove = false;
+                        return false;
                     else if (routeValue.equals(sub) && rel.hasKey("restriction:" + sub))
-                        remove = false;
+                        return false;
                 }
-                return remove;
+                return true;
             }
         });
 

--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/actions/mendrelation/PublicTransportMendRelationAction.java
@@ -1122,12 +1122,19 @@ public class PublicTransportMendRelationAction extends AbstractMendRelation {
             else {
                 boolean remove = true;
                 String routeValue = relation.get("route");
-                for (String s : restrictions) {
-                    String sub = s.substring(12);
-                    if (routeValue.equals(sub) && rel.hasTag("type", s))
+                String[] restrictionTypes = Arrays.stream(restrictions)
+                    .filter(s -> s.startsWith("restriction:"))
+                    .map(s -> s.substring("restriction:".length()))
+                    .toArray(String[]::new);
+
+                for (String type : restrictionTypes) {
+                    if (!routeValue.equals(type)) {
+                        continue;
+                    }
+
+                    if (rel.hasKey("restriction:" + type) || rel.hasTag("type", type)) {
                         remove = false;
-                    else if (routeValue.equals(sub) && rel.hasKey("restriction:" + sub))
-                        remove = false;
+                    }
                 }
                 return remove;
             }


### PR DESCRIPTION
Fixes JOSM [#23708](https://josm.openstreetmap.de/ticket/23708).

The `PublicTransportMendRelationAction.isRestricted` method checks against a hardcoded list of vehicle types:

```
["restriction", "restriction:bus", "restriction:trolleybus", ...]
```

However, it tries to pull out the subtype and fails on that first entry, since there is no subtype in `"restriction"`.

This change will filter the list of restrictions for only those with subtypes.