### PR TITLE
Update RouteUtils.java added oneway test

### DIFF
--- a/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/utils/RouteUtils.java
+++ b/src/main/java/org/openstreetmap/josm/plugins/pt_assistant/utils/RouteUtils.java
@@ -180,7 +180,7 @@ public final class RouteUtils {
 
             if (!way.hasTag("busway", "lane") && !way.hasTag("busway", "opposite_lane")
                     && !way.hasTag("busway:left", "lane") && !way.hasTag("busway:right", "lane")
-                    && !way.hasTag("oneway:bus", "no") && !way.hasTag("oneway:psv", "no")
+                    && !way.hasTag("oneway:bus", "no") && !way.hasTag("oneway","no") && !way.hasTag("oneway:psv", "no")
                     && !way.hasTag("trolley_wire", "backward")) {
 
                 if (OsmUtils.isReversed(way.get("oneway"))) {


### PR DESCRIPTION
In some ways, there is an explicit key-tag pair that specifies that the way is **not** oneway as in "oneway:no". The current logic will incorrectly flag such a way as being oneway. the committed changes adds a condition to check if the oneway is actually just "oneway:no". 

Further testing might be necessary as well as reordering or moving the condition to improve efficiency and/or readability are welcome.